### PR TITLE
dont remove umlauts from query

### DIFF
--- a/src/models/Providers/Sqlite.php
+++ b/src/models/Providers/Sqlite.php
@@ -116,7 +116,7 @@ class Sqlite extends Provider
     public function search(string $query, array $options, $collection = null): array
     {
         // Remove punctuation from query
-        $query = preg_replace('/[^a-z0-9]+/i', '', $query);
+        $query = preg_replace('/[^a-z0-9äöüÄÖÜß]+/i', '', $query);
 
         // Generate options with defaults
         $options = array_merge($this->options, $options);


### PR DESCRIPTION
changed  the regex to exclude german umlauts as well.
so that the query 'hühnchen' doesn't get transformed to 'hnchen'
there is maybe a better way?

Fixes #

## Proposed Changes

  -
  -
  -
